### PR TITLE
Cleanup and refactor

### DIFF
--- a/BwRegulator.scala
+++ b/BwRegulator.scala
@@ -164,7 +164,6 @@ class BwRegulatorModule(outer: BwRegulator, params: BRUParams) extends LazyModul
     }
 
     out <> in
-    out.a.bits.domainId := domainIds(i)
     io.nThrottleWb(i) := false.B
 
     when (enBRUGlobal && bwREnables(i)) {


### PR DESCRIPTION
Makes bank mask parameterized
Makes monitor interface counters option types so you can choose to have them in design via boolean parameter
Cleanup parameters
Specify that the BRU is an LLC regulator in naming


